### PR TITLE
refactor: convert concat!() to multiline string literal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,13 +141,11 @@ async fn bool(cli: Cli, message: String) -> Result<BoolResponse> {
 
     println!("Sending message to Claude...\n");
 
-    let system = concat!(
-        "consider the question or statement and answer with a true or false.",
-        "\nwhen unable to assess as a question or statement, default to false and explain.",
-        "\nencode the result to a json object.",
-        "\nthe object should have a key 'answer' with a boolean value.",
-        "\nthe object should have a key 'explanation' with a string value.",
-    );
+    let system = "consider the question or statement and answer with a true or false.
+when unable to assess as a question or statement, default to false and explain.
+encode the result to a json object.
+the object should have a key 'answer' with a boolean value.
+the object should have a key 'explanation' with a string value.";
 
     let messages = Messages::new().push_user(message).clone();
 


### PR DESCRIPTION
Refactored the system prompt in the bool function from using concat!() macro to a cleaner multiline string literal for better readability.

Fixes #16

---

Generated with [Claude Code](https://claude.ai/code)